### PR TITLE
Use github tags instead of branches

### DIFF
--- a/src/build/prerequisites.md
+++ b/src/build/prerequisites.md
@@ -95,9 +95,9 @@ cd ~/cudos
 2. Make sure that you are in the correct directory (cudos directory in this example)
 3. Clone the correct branches from the [CudosNode](https://github.com/CudoVentures/cudos-node), [CudosBuilders](https://github.com/CudoVentures/cudos-builders), and [CudosGravityBridge](https://github.com/CudoVentures/cosmos-gravity-bridge) repositories with renaming the folders accordingly to exactly _CudosNode_, _CudosBuilders_, and _CudosGravityBridge_:
 ```
-git clone --depth 1 --branch gravity/sdk-0.43 https://github.com/CudoVentures/cudos-node.git CudosNode
-git clone --depth 1 --branch sdk-0.43  https://github.com/CudoVentures/cudos-builders.git CudosBuilders
-git clone --depth 1 --branch cosmos-sdk-0.43 https://github.com/CudoVentures/cosmos-gravity-bridge.git CudosGravityBridge
+git clone --depth 1 --branch v0.2 https://github.com/CudoVentures/cudos-node.git CudosNode
+git clone --depth 1 --branch v0.3  https://github.com/CudoVentures/cudos-builders.git CudosBuilders
+git clone --depth 1 --branch v0.2 https://github.com/CudoVentures/cosmos-gravity-bridge.git CudosGravityBridge
 ```
 4. Navigate to the _CudosBuilders_ directory
 5. Build the docker image of the binary by running the command:

--- a/src/build/start-binaries.md
+++ b/src/build/start-binaries.md
@@ -13,9 +13,9 @@ cd ~/cudos
 2. Make sure that you are in the correct directory (cudos directory in this example)
 3. Clone the correct branches from the [CudosNode](https://github.com/CudoVentures/cudos-node), [CudosBuilders](https://github.com/CudoVentures/cudos-builders), and [CudosGravityBridge](https://github.com/CudoVentures/cosmos-gravity-bridge) repositories with renaming the folders accordingly to exactly _CudosNode_, _CudosBuilders_, and _CudosGravityBridge_:
 ```
-git clone --depth 1 --branch gravity/sdk-0.43 https://github.com/CudoVentures/cudos-node.git CudosNode
-git clone --depth 1 --branch sdk-0.43  https://github.com/CudoVentures/cudos-builders.git CudosBuilders
-git clone --depth 1 --branch cosmos-sdk-0.43 https://github.com/CudoVentures/cosmos-gravity-bridge.git CudosGravityBridge
+git clone --depth 1 --branch v0.2 https://github.com/CudoVentures/cudos-node.git CudosNode
+git clone --depth 1 --branch v0.3  https://github.com/CudoVentures/cudos-builders.git CudosBuilders
+git clone --depth 1 --branch v0.2 https://github.com/CudoVentures/cosmos-gravity-bridge.git CudosGravityBridge
 ```
 4. Navigate to the directory _CudosBuilders/docker/binary-builder_ directory
 5. Build and start the binaries by running this command:


### PR DESCRIPTION
We've created tags/releases in order to avoid messing the code in branches. So instead of checking out a branch which might have been modified, it is better to clone a specific tag.