### PR TITLE
update github tags

### DIFF
--- a/src/build/prerequisites.md
+++ b/src/build/prerequisites.md
@@ -103,9 +103,9 @@ cd ~/cudos
 2. Make sure that you are in the correct directory (cudos directory in this example)
 3. Clone the correct branches from the [CudosNode](https://github.com/CudoVentures/cudos-node), [CudosBuilders](https://github.com/CudoVentures/cudos-builders), and [CudosGravityBridge](https://github.com/CudoVentures/cosmos-gravity-bridge) repositories with renaming the folders accordingly to exactly _CudosNode_, _CudosBuilders_, and _CudosGravityBridge_:
 ```
-git clone --depth 1 --branch v0.3 https://github.com/CudoVentures/cudos-node.git CudosNode
-git clone --depth 1 --branch v0.3.2  https://github.com/CudoVentures/cudos-builders.git CudosBuilders
-git clone --depth 1 --branch v0.3 https://github.com/CudoVentures/cosmos-gravity-bridge.git CudosGravityBridge
+git clone --depth 1 --branch v0.4.0 https://github.com/CudoVentures/cudos-node.git CudosNode
+git clone --depth 1 --branch v0.3.3  https://github.com/CudoVentures/cudos-builders.git CudosBuilders
+git clone --depth 1 --branch v0.4.0 https://github.com/CudoVentures/cosmos-gravity-bridge.git CudosGravityBridge
 ```
 4. Navigate to the _CudosBuilders_ directory
 5. Build the docker image of the binary by running the command:

--- a/src/build/start-binaries.md
+++ b/src/build/start-binaries.md
@@ -13,9 +13,9 @@ cd ~/cudos
 2. Make sure that you are in the correct directory (cudos directory in this example)
 3. Clone the correct branches from the [CudosNode](https://github.com/CudoVentures/cudos-node), [CudosBuilders](https://github.com/CudoVentures/cudos-builders), and [CudosGravityBridge](https://github.com/CudoVentures/cosmos-gravity-bridge) repositories with renaming the folders accordingly to exactly _CudosNode_, _CudosBuilders_, and _CudosGravityBridge_:
 ```
-git clone --depth 1 --branch v0.3 https://github.com/CudoVentures/cudos-node.git CudosNode
-git clone --depth 1 --branch v0.3.2  https://github.com/CudoVentures/cudos-builders.git CudosBuilders
-git clone --depth 1 --branch v0.3 https://github.com/CudoVentures/cosmos-gravity-bridge.git CudosGravityBridge
+git clone --depth 1 --branch v0.4.0 https://github.com/CudoVentures/cudos-node.git CudosNode
+git clone --depth 1 --branch v0.3.3  https://github.com/CudoVentures/cudos-builders.git CudosBuilders
+git clone --depth 1 --branch v0.4.0 https://github.com/CudoVentures/cosmos-gravity-bridge.git CudosGravityBridge
 ```
 4. Navigate to the directory _CudosBuilders/docker/binary-builder_ directory
 5. Build and start the binaries by running this command:

--- a/src/build/validator.md
+++ b/src/build/validator.md
@@ -221,7 +221,7 @@ You can use either an existing [Ethereum full-node](https://ethereum.org/en/deve
 1. Run your Ethereum binary on a different machine that your validator is running
 2. Clone the correct branch from the [CudosBuilders](https://github.com/CudoVentures/cudos-builders) repository with renaming the folders accordingly to exactly _CudosBuilders_:
 ```
-git clone --depth 1 --branch v0.3 https://github.com/CudoVentures/cudos-builders.git CudosBuilders
+git clone --depth 1 --branch v0.3.3 https://github.com/CudoVentures/cudos-builders.git CudosBuilders
 ```
 3. Open shell, navigate to the directory _CudosBuilders/docker/ethereum_ and start the Ethereum full-node by running the command:
 ```


### PR DESCRIPTION
I've updated github tags from docs regarding how to connect to the network.

Please, remove the need of an orchestrator when creating a validator from the docs, because orchestrators are no longer needed after today's hard-fork.